### PR TITLE
Refactor/74 의도하지 않은 update 쿼리 해결

### DIFF
--- a/src/main/java/com/yapp/pet/domain/pet/service/PetService.java
+++ b/src/main/java/com/yapp/pet/domain/pet/service/PetService.java
@@ -53,10 +53,11 @@ public class PetService {
                        .sizeType(petRequest.getSizeType())
                        .build();
 
-        petRequest.getTags()
-                  .forEach(tag -> petTagService.createPetTag(pet, tag));
 
         petRepository.save(pet);
+
+        petRequest.getTags()
+                  .forEach(tag -> petTagService.createPetTag(pet, tag));
 
         return pet.getId();
     }


### PR DESCRIPTION
1:N 관계에서 N을 먼저 저장하고 1을 저장하게 되면, N이 insert 될 때 외래키가 null인 상태로 저장이 되고, 1을 저장하는 순간 외래키인 null인 것이 1을 참조하기 때문에 update 쿼리가 나가게 된다
이에 1을 먼저 저정하고, N이 연관관계 맺으면서 저장하게 되면 update 쿼리가 추가로 나가지 않게 된다

### PR Type
- [x] Refactoring (no functional changes, no api changes)

### Fix Issue
- resolved: #74 

### Feature description
- PetTag 저장 시 PetTag를 저장하는 insert 쿼리가 나간 후 update 쿼리가 추가로 나감

### Checklist

- [x] PetTag 저장 시 update 쿼리가 추가로 나가지 않는다
- [x] 기존 테스트가 제대로 작동한다

Example
- [x] Work