### PR TITLE
Feature/79 댓글 조회 api 추가

### DIFF
--- a/src/main/java/com/yapp/pet/domain/comment/CommentQueryService.java
+++ b/src/main/java/com/yapp/pet/domain/comment/CommentQueryService.java
@@ -1,10 +1,15 @@
 package com.yapp.pet.domain.comment;
 
+import com.yapp.pet.domain.account.entity.Account;
+import com.yapp.pet.web.comment.model.CommentResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.ZoneId;
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -16,5 +21,19 @@ public class CommentQueryService {
     public Comment findCommentById(long commentId) {
         return commentRepository.findById(commentId)
                                 .orElseThrow(NoSuchElementException::new);
+    }
+
+    public List<CommentResponse> findComment(long clubId, Account account) {
+        List<Comment> comments = commentRepository.findCommentByClubId(clubId);
+
+        return comments.stream()
+                       .map(comment -> new CommentResponse(comment.getContent(),
+                                                           comment.getAccount().getNickname(),
+                                                           comment.getClub().getAccountClubs().stream()
+                                                                  .anyMatch(ac -> (ac.isLeader() && ac.getAccount()
+                                                                                                      .equals(account))),
+                                                           comment.getUpdatedAt()
+                                                                  .atZone(ZoneId.of("Asia/Seoul"))))
+                       .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/yapp/pet/domain/comment/CommentRepository.java
+++ b/src/main/java/com/yapp/pet/domain/comment/CommentRepository.java
@@ -1,6 +1,12 @@
 package com.yapp.pet.domain.comment;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @EntityGraph(attributePaths = {"account", "club"})
+    List<Comment> findCommentByClubId(long clubId);
 }

--- a/src/main/java/com/yapp/pet/domain/comment/CommentService.java
+++ b/src/main/java/com/yapp/pet/domain/comment/CommentService.java
@@ -2,8 +2,6 @@ package com.yapp.pet.domain.comment;
 
 import com.yapp.pet.domain.account.entity.Account;
 import com.yapp.pet.domain.club.ClubQueryService;
-import com.yapp.pet.domain.club.entity.Club;
-import com.yapp.pet.domain.club.repository.ClubRepository;
 import com.yapp.pet.web.comment.model.CommentRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/yapp/pet/web/comment/CommentController.java
+++ b/src/main/java/com/yapp/pet/web/comment/CommentController.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/yapp/pet/web/comment/model/CommentResponse.java
+++ b/src/main/java/com/yapp/pet/web/comment/model/CommentResponse.java
@@ -1,0 +1,23 @@
+package com.yapp.pet.web.comment.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentResponse {
+
+    private String content;
+
+    private String author;
+
+    private boolean leader;
+
+    private ZonedDateTime updatedTime;
+}


### PR DESCRIPTION
### PR Type
- [x] Feature

### Fix Issue
- resolved: #79 

### Feature description
- 모임에 있는 댓글들을 모두 조회할 수 있다
- 댓글을 조회할 때, 모임을 만든 사람의 댓글일 경우에는 leader 값을 true로 반환한다
- 단독적으로 댓글을 조회하는 경우는 없기 때문에 api는 따로 작성하지 않음

### Checklist

- [x] 댓글들이 모두 조회되는가?
- [x] 모임을 만든 사람이 댓글을 작성할 경우 leader의 값이 true로 반환되는가?

Example
- [x] Work

### Screenshots
#### 현재 로그인 된 계정의 닉네임은 재롱잔치
- 재롱잔치가 1번 모임을 만들고, 댓글을 작성할 경우 true 반환
- 다른 유저가 3번 모임을 만들고, 재롱잔치가 댓글을 작성할 경우 false 반환

![image](https://user-images.githubusercontent.com/62413589/175784063-4f3e3dc7-c3ba-4f13-96f4-b58441e657a8.png)
![image](https://user-images.githubusercontent.com/62413589/175784071-b7edf5af-6627-43ee-9ce7-f9a16c076767.png)




