### PR TITLE
fix: 회원정보 수정 시, 주소값 null 여부 검사 수정

### DIFF
--- a/src/main/java/com/yapp/pet/domain/account/entity/Account.java
+++ b/src/main/java/com/yapp/pet/domain/account/entity/Account.java
@@ -113,8 +113,12 @@ public class Account extends BaseEntity {
             this.sex = updateAccount.getSex();
         }
 
-        if (updateAccount.getAddress() != null) {
-            this.address = updateAccount.getAddress();
+        if (updateAccount.getAddress().getCity() != null) {
+            this.address.updateCity(updateAccount.getAddress().getCity());
+        }
+
+        if (updateAccount.getAddress().getDetail() != null) {
+            this.address.updateDetail(updateAccount.getAddress().getDetail());
         }
 
         if (StringUtils.hasText(updateAccount.getSelfIntroduction())) {

--- a/src/main/java/com/yapp/pet/domain/account/entity/Address.java
+++ b/src/main/java/com/yapp/pet/domain/account/entity/Address.java
@@ -16,4 +16,12 @@ public class Address {
     private String city;
     private String detail;
 
+    public void updateCity(String city){
+        this.city = city;
+    }
+
+    public void updateDetail(String detail){
+        this.detail = detail;
+    }
+
 }


### PR DESCRIPTION
### PR Type
- [x] Bug Fix


### Fix Issue
- resolved: #129 

### Fix description
회원 정보 수정시 주소 데이터를 입력하지 않는 경우 null으로 업데이트 되는 이슈를 해결합니다.

### Checklist
- [x] Embedded가 아닌 Embedded의 필드를 null 여부 검사
