### PR TITLE
Fix/151 댓글 조회 시 NPE 처리

### DIFF
--- a/src/main/java/com/yapp/pet/domain/account/entity/Account.java
+++ b/src/main/java/com/yapp/pet/domain/account/entity/Account.java
@@ -133,6 +133,10 @@ public class Account extends BaseEntity {
         return this.nickname.equals(account.getNickname());
     }
 
+    public boolean hasImage() {
+        return accountImage != null;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/yapp/pet/domain/comment/service/CommentQueryService.java
+++ b/src/main/java/com/yapp/pet/domain/comment/service/CommentQueryService.java
@@ -1,6 +1,8 @@
 package com.yapp.pet.domain.comment.service;
 
 import com.yapp.pet.domain.account.entity.Account;
+import com.yapp.pet.domain.accountclub.AccountClub;
+import com.yapp.pet.domain.club.entity.Club;
 import com.yapp.pet.domain.comment.Comment;
 import com.yapp.pet.domain.comment.CommentRepository;
 import com.yapp.pet.domain.pet.entity.Pet;
@@ -9,15 +11,18 @@ import com.yapp.pet.web.comment.model.CommentResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZoneId;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Slf4j
 @Service
+@Transactional(readOnly = true)
 public class CommentQueryService {
 
     private final CommentRepository commentRepository;
@@ -38,15 +43,23 @@ public class CommentQueryService {
                        .map(comment -> new CommentResponse(comment.getId(),
                                                            comment.getContent(),
                                                            comment.getAccount().getNickname(),
-                                                           comment.getClub().getAccountClubs().stream()
-                                                                  .anyMatch(ac -> (ac.isLeader() && ac.getAccount()
-                                                                                                      .equals(comment.getAccount()))),
-                                                           comment.getUpdatedAt()
-                                                                  .atZone(ZoneId.of("Asia/Seoul")),
-                                                           savedPet.stream().map(Pet::getBreed)
+                                                           isLeader(comment.getClub(), comment),
+                                                           comment.getUpdatedAt() != null ? comment.getUpdatedAt()
+                                                                                                   .atZone(ZoneId.of(
+                                                                                                           "Asia/Seoul")) : null,
+                                                           savedPet.stream()
+                                                                   .filter(Objects::nonNull)
+                                                                   .map(Pet::getBreed)
                                                                    .collect(Collectors.toList()),
-                                                           comment.getAccount().getAccountImage().getPath()))
+                                                           comment.getAccount().hasImage() ? comment.getAccount()
+                                                                                                    .getAccountImage()
+                                                                                                    .getPath() : null))
                        .collect(Collectors.toList());
     }
 
+    private boolean isLeader(Club club, Comment comment) {
+        return club.getAccountClubs().stream()
+                   .filter(AccountClub::isLeader)
+                   .anyMatch(ac -> ac.getAccount().equals(comment.getAccount()));
+    }
 }

--- a/src/main/java/com/yapp/pet/domain/comment/service/CommentService.java
+++ b/src/main/java/com/yapp/pet/domain/comment/service/CommentService.java
@@ -19,14 +19,12 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final ClubQueryService clubQueryService;
 
-    public Long addComment(Account account, CommentRequest commentRequest) {
+    public void addComment(Account account, CommentRequest commentRequest) {
 
         Comment comment = Comment.of(commentRequest.getContent(), account,
                                 clubQueryService.findClubById(commentRequest.getClubId()));
 
         commentRepository.save(comment);
-
-        return comment.getId();
     }
 
     public Long deleteComment(Account account, long commentId) {

--- a/src/main/java/com/yapp/pet/web/comment/CommentController.java
+++ b/src/main/java/com/yapp/pet/web/comment/CommentController.java
@@ -1,8 +1,10 @@
 package com.yapp.pet.web.comment;
 
 import com.yapp.pet.domain.account.entity.Account;
+import com.yapp.pet.domain.club.service.ClubQueryService;
 import com.yapp.pet.domain.comment.service.CommentService;
 import com.yapp.pet.global.annotation.AuthAccount;
+import com.yapp.pet.web.club.model.ClubFindDetailResponse;
 import com.yapp.pet.web.comment.model.CommentRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,12 +24,12 @@ public class CommentController {
 
     private final CommentService commentService;
 
+    private final ClubQueryService clubQueryService;
+
     @PostMapping("/comments")
-    public ResponseEntity<Long> create(@AuthAccount Account account, @RequestBody CommentRequest commentRequest) {
+    public ResponseEntity<ClubFindDetailResponse> create(@AuthAccount Account account, @RequestBody CommentRequest commentRequest) {
 
-        Long commentId = commentService.addComment(account, commentRequest);
-
-        return ResponseEntity.ok(commentId);
+        return ResponseEntity.ok(clubQueryService.findClubDetail(commentRequest.getClubId(), account));
     }
 
     @DeleteMapping("/comments/{comment-id}")

--- a/src/main/java/com/yapp/pet/web/comment/model/CommentResponse.java
+++ b/src/main/java/com/yapp/pet/web/comment/model/CommentResponse.java
@@ -1,6 +1,7 @@
 package com.yapp.pet.web.comment.model;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,7 +12,6 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 public class CommentResponse {
 
     private Long id;
@@ -27,4 +27,16 @@ public class CommentResponse {
     private List<String> breeds;
 
     private String imageUrl;
+
+    @Builder
+    public CommentResponse(Long id, String content, String author, boolean leader, ZonedDateTime updatedTime,
+                           List<String> breeds, String imageUrl) {
+        this.id = id;
+        this.content = content;
+        this.author = author;
+        this.leader = leader;
+        this.updatedTime = updatedTime;
+        this.breeds = breeds;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/resources/static/openapi.yml
+++ b/src/main/resources/static/openapi.yml
@@ -710,7 +710,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ExceptionResponseInfo'
+                $ref: '#/components/schemas/ClubFindDetailResponse'
   /api/comments/{comment-id}:
     delete:
       tags:

--- a/src/test/java/com/yapp/pet/domain/comment/service/CommentQueryServiceTest.java
+++ b/src/test/java/com/yapp/pet/domain/comment/service/CommentQueryServiceTest.java
@@ -1,0 +1,112 @@
+package com.yapp.pet.domain.comment.service;
+
+import com.yapp.pet.domain.account.entity.Account;
+import com.yapp.pet.domain.account_image.AccountImage;
+import com.yapp.pet.domain.club.entity.Club;
+import com.yapp.pet.domain.comment.Comment;
+import com.yapp.pet.domain.comment.CommentRepository;
+import com.yapp.pet.domain.pet.entity.Pet;
+import com.yapp.pet.domain.pet.repository.PetRepository;
+import com.yapp.pet.web.comment.model.CommentResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("CommentQueryService Unit Test")
+class CommentQueryServiceTest {
+
+    CommentRepository commentRepository;
+
+    PetRepository petRepository;
+
+    CommentQueryService commentQueryService;
+
+    @BeforeEach
+    void setUp() {
+        commentRepository = mock(CommentRepository.class);
+        petRepository = mock(PetRepository.class);
+
+        commentQueryService = new CommentQueryService(commentRepository, petRepository);
+    }
+
+    @Test
+    @DisplayName("findComment() : 댓글 조회 시 Account가 Pet이 없을 경우에는 Pet 정보를 넣지 않는다")
+    void testFindCommentPetNull() throws Exception {
+        //given
+        AccountImage accountImage = AccountImage.builder()
+                                                .path("path")
+                                                .build();
+
+        Account account = Account.builder()
+                                 .nickname("account1")
+                                 .accountImage(accountImage)
+                                 .build();
+
+        Club club = Club.builder()
+                        .title("title1")
+                        .build();
+
+        List<Comment> comments = List.of(Comment.of("content", account, club));
+        List<Pet> pets = new ArrayList<>();
+
+        //when
+        when(commentRepository.findCommentByClubId(anyLong()))
+                .thenReturn(comments);
+        when(petRepository.findPetsByAccountId(anyLong()))
+                .thenReturn(pets);
+
+        List<CommentResponse> comment = commentQueryService.findComment(1L, account);
+
+        verify(commentRepository, times(1)).findCommentByClubId(anyLong());
+        verify(petRepository, times(1)).findPetsByAccountId(any());
+
+        //then
+        assertAll(
+                () -> assertEquals(comment.size(), 1),
+                () -> assertEquals(comment.get(0).getBreeds().size(), 0)
+        );
+    }
+
+    @Test
+    @DisplayName("findComment() : 댓글 조회 시 Account의 Image가 없을 경우에는 accountImage를 null로 한다")
+    void testFindCommentImageNull() throws Exception {
+        //given
+        Account account = Account.builder()
+                                 .nickname("account1")
+                                 .build();
+
+        Club club = Club.builder()
+                        .title("title1")
+                        .build();
+
+        List<Comment> comments = List.of(Comment.of("content", account, club));
+        List<Pet> pets = List.of(Pet.builder()
+                                    .name("pet1")
+                                    .build());
+
+        //when
+        when(commentRepository.findCommentByClubId(anyLong()))
+                .thenReturn(comments);
+        when(petRepository.findPetsByAccountId(anyLong()))
+                .thenReturn(pets);
+
+        List<CommentResponse> comment = commentQueryService.findComment(1L, account);
+
+        //then
+        assertAll(
+                () -> assertEquals(comment.size(), 1),
+                () -> assertThat(comment.get(0).getImageUrl()).isNull());
+    }
+}


### PR DESCRIPTION
### PR Type
- [x] Bug Fix

### Fix Issue
- resolved: #151 

### Feature description
- 댓글 조회 시 Pet, AccountImage가 없을 시에 NPE 처리
- 댓글 생성 시 모임 세부 정보 반환

### Checklist

- [x] 댓글 조회 시 Pet, AccountImage가 제대로 null로 반환되는가?

Example
- [x] Work