### PR TITLE
Fix/161 댓글 조회 시 pet 없는 유저는 댓글이 

### DIFF
--- a/src/main/java/com/yapp/pet/domain/club/service/ClubService.java
+++ b/src/main/java/com/yapp/pet/domain/club/service/ClubService.java
@@ -73,9 +73,9 @@ public class ClubService {
         clubRepository.save(club);
 
         AccountClub accountClub = AccountClub.of(account, club);
-        accountClubRepository.save(accountClub);
-
         club.addAccountClub(accountClub);
+
+        accountClubRepository.save(accountClub);
 
         return club.getId();
     }

--- a/src/main/java/com/yapp/pet/global/mapper/ClubMapper.java
+++ b/src/main/java/com/yapp/pet/global/mapper/ClubMapper.java
@@ -27,6 +27,6 @@ public interface ClubMapper {
 
     @Named("toZonedDateTime")
     default ZonedDateTime toZonedDateTime(LocalDateTime localDateTime) {
-        return ZonedDateTime.of(localDateTime, ZoneId.of("Asia/Seoul"));
+        return ZonedDateTime.of(localDateTime, ZoneId.of("UTC"));
     }
 }


### PR DESCRIPTION
### PR Type
- [x] Bug Fix

### Fix Issue
- resolved: #161 

### Feature description
- 댓글 조회 시, 해당 댓글의 Account 펫 정보가 조회
- 댓글 생성 시, 모든 댓글의 Account 펫 정보가 잘 조회됨
- 시간을 Asia/Seoul -> UTC로 변경
