### PR TITLE
hotfix: OSIV off로 인해 변경감지를 사용하지 않고, 직접 save() 사용

### DIFF
--- a/src/main/java/com/yapp/pet/domain/account/service/AccountService.java
+++ b/src/main/java/com/yapp/pet/domain/account/service/AccountService.java
@@ -126,9 +126,8 @@ public class AccountService {
             );
         }
 
-        Account updateAccount = accountMapper.toEntity(request);
-
-        account.update(updateAccount);
+        account.update(accountMapper.toEntity(request));
+        accountRepository.save(account);
 
         return account.getId();
     }


### PR DESCRIPTION
### PR Type
- [x] Bug Fix

### Fix Issue
- resolved: #163 

### Feature description
OSIV 옵션을 off 하게 되면, Service의 수정 메서드에서 트랜잭션을 시작(여기서 영속성 컨텍스트 생성)하므로
resolver에서 조회한 Account가 트랜잭션 시작 시점의 영속성 컨텍스트에 존재하지 않음
따라서 변경감지가 동작하지 않는 이슈 발생

변경감지가 아닌 직접 save()