### PR TITLE
fix: 애플로그인 로직 수정

### DIFF
--- a/src/main/java/com/yapp/pet/domain/account/entity/Account.java
+++ b/src/main/java/com/yapp/pet/domain/account/entity/Account.java
@@ -139,6 +139,10 @@ public class Account extends BaseEntity {
         return accountImage != null;
     }
 
+    public void addToken(Token token) {
+        this.token = token;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/yapp/pet/domain/account/repository/AccountRepository.java
+++ b/src/main/java/com/yapp/pet/domain/account/repository/AccountRepository.java
@@ -7,10 +7,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 public interface AccountRepository extends JpaRepository<Account, Long>, AccountRepositoryCustom {
 
     @Modifying
     @Transactional
     @Query("update Account a set a.token = null where a.id = :id")
     void deleteToken(@Param("id") Long id);
+
+    Optional<Account> findByEmail(@Param("email") String email);
 }

--- a/src/main/java/com/yapp/pet/domain/token/entity/Token.java
+++ b/src/main/java/com/yapp/pet/domain/token/entity/Token.java
@@ -55,6 +55,7 @@ public class Token extends BaseEntity {
 
     public void addAccount(Account account){
         this.account = account;
+        account.addToken(this);
     }
 
     public void deleteAccount() {


### PR DESCRIPTION
### PR Type
- [x] Bug Fix

### Fix Issue
- resolved: #171

### Feature description
- 로그아웃 후 재로그인 하는 경우 에러를 해결합니다.
- 로그아웃시 refresh token을 삭제하는데, 재로그인과 신규회원 여부 판단을 token으로 하다보니 에러가 발생합니다.

### Checklist
- [x] 재로그인, 신규회원 여부 판단을 이메일로 변경
