### PR TITLE
DB Replication을 통한 read/write DB 분리

### DIFF
--- a/src/main/java/com/yapp/pet/global/config/routing/DataSourceConfiguration.java
+++ b/src/main/java/com/yapp/pet/global/config/routing/DataSourceConfiguration.java
@@ -1,0 +1,63 @@
+package com.yapp.pet.global.config.routing;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class DataSourceConfiguration {
+
+    public static final String PRIMARY_DATASOURCE = "primaryDataSource";
+    public static final String SECONDARY_DATASOURCE = "secondaryDataSource";
+
+    @Bean(PRIMARY_DATASOURCE)
+    @ConfigurationProperties(prefix = "spring.datasource.primary.hikari")
+    public DataSource primaryDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean(SECONDARY_DATASOURCE)
+    @ConfigurationProperties(prefix = "spring.datasource.secondary.hikari")
+    public DataSource secondaryDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean
+    @Primary
+    @DependsOn({PRIMARY_DATASOURCE, SECONDARY_DATASOURCE})
+    public DataSource routingDataSource(@Qualifier(PRIMARY_DATASOURCE) DataSource primaryDataSource,
+                                        @Qualifier(SECONDARY_DATASOURCE) DataSource secondaryDataSource) {
+
+        RoutingDataSource routingDataSource = new RoutingDataSource();
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+
+        dataSourceMap.put("primary", primaryDataSource);
+        dataSourceMap.put("secondary", secondaryDataSource);
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(primaryDataSource);
+
+        return routingDataSource;
+    }
+
+    @Bean
+    @DependsOn("routingDataSource")
+    public LazyConnectionDataSourceProxy dataSource(DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+
+}

--- a/src/main/java/com/yapp/pet/global/config/routing/RoutingDataSource.java
+++ b/src/main/java/com/yapp/pet/global/config/routing/RoutingDataSource.java
@@ -1,0 +1,14 @@
+package com.yapp.pet.global.config.routing;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        return TransactionSynchronizationManager.isCurrentTransactionReadOnly()
+                ? "secondary"
+                : "primary";
+    }
+}

--- a/src/main/resources/config/application-dev.yaml
+++ b/src/main/resources/config/application-dev.yaml
@@ -1,9 +1,22 @@
 spring:
   datasource:
-    url: ENC(zwJFK8HCOJbOI+PMINipGtjyA8QrfgSebqpEx84L/IsZtceoeff+Wk/cksUiesNLmn86NjlZge7YD9kZrGJFo5KIKYcuxvcyfhQeyjMNLRtZ+G0Ef7dNLDEoJiKPkskGcPTOwjZR2Pmy6UWShrNg8g==)
-    username: ENC(OTUfXu9X9QBk4lG0mm19+A==)
-    password: ENC(8d+CPaIyBQOntW/l/k6WlE9NqDqx5eoR)
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    primary:
+      hikari:
+        type: com.zaxxer.hikari.HikariDataSource
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        username: ENC(k9HvXvq0ejpgRDN8hTCAbw==)
+        password: ENC(v4QCGkCugrZgtG5jCtpv1FeOliW7aPk7)
+        jdbc-url: ENC(kl+In8I7PIjG/DCtzDCoHwTqqTCUkI93MJY1KZ4pLoHMqLI2w9j6UCgbITRHPY2NnqpRwZ3tje4pHyXAQDOTuKSLOvccr8Aqi40VXsMQWud6ZgPFhThta516MbVxdVFQpF7BDnPPi0Y6/m5yKeMu9CvQxx92AYngwWBdDWTsqAolemNQv27Ol2FbIlAKgQFi)
+    secondary:
+      hikari:
+        type: com.zaxxer.hikari.HikariDataSource
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        username: ENC(k9HvXvq0ejpgRDN8hTCAbw==)
+        password: ENC(v4QCGkCugrZgtG5jCtpv1FeOliW7aPk7)
+        jdbc-url: ENC(jn/yj4U8HpOKeZfZtrUGdseTZ3h/u9o5FTRyQ9DEqzL7hd+xWQO8UUJCwtPNlV4ka1/E5by+cwUfN8jxss+kQgDq6DYioNoSa+us5uyGe26GSzqjuIbsTCWssudhyA3QWQKHXF8+5PZAb3/+v7f7QXvzmEBoTRVv1ILpqdLe88RcvgWa7YFWeRWJCa3b6azZcnf26dtRKQM=)
+    hikari:
+      pool-name: Hikari
+      auto-commit: false
   servlet:
     multipart:
       max-file-size: 100MB
@@ -12,7 +25,6 @@ spring:
   redis:
     host: ENC(IZFO1niFTPUsQI0SmRYmo0ycPEVaLVLW)
     port: 6379
-
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/config/application-local.yaml
+++ b/src/main/resources/config/application-local.yaml
@@ -3,10 +3,23 @@ spring:
     activate:
       on-profile: "local"
   datasource:
-    url: jdbc:mysql://localhost:3306/pet?characterEncoding=UTF-8&serverTimezone=UCT
-    username: root
-    password: 1234
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    primary:
+      hikari:
+        type: com.zaxxer.hikari.HikariDataSource
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        username: root
+        password: 1234
+        jdbc-url: jdbc:mysql://localhost:3306/pet?characterEncoding=UTF-8&serverTimezone=UCT
+    secondary:
+      hikari:
+        type: com.zaxxer.hikari.HikariDataSource
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        username: root
+        password: 1234
+        jdbc-url: jdbc:mysql://localhost:3306/pet?characterEncoding=UTF-8&serverTimezone=UCT
+    hikari:
+      pool-name: Hikari
+      auto-commit: false
   servlet:
     multipart:
       max-file-size: 100MB
@@ -15,7 +28,6 @@ spring:
   redis:
     host: localhost
     port: 6379
-
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
### PR Type
- [x] Refactoring (no functional changes, no api changes)

### Fix Issue
- resolved: #174 

### Feature description
- AWS Aurora를 활용하여 DB Replication을 수행합니다.
- Read용 DB와 Wirte용 DB를 분리합니다.
- 스프링 @Transactional readOnly 옵션에따라 Primary DB와 Secondary DB 커넥션을 획득할 수 있습니다.

