### PR TITLE
Fix/186 범위 내에 있는 모임 조회 시 참여 가능한 모임만 조회

### DIFF
--- a/src/main/java/com/yapp/pet/domain/account/service/AccountService.java
+++ b/src/main/java/com/yapp/pet/domain/account/service/AccountService.java
@@ -5,7 +5,9 @@ import com.yapp.pet.domain.account.entity.Account;
 import com.yapp.pet.domain.account.repository.AccountRepository;
 import com.yapp.pet.domain.account_image.AccountImage;
 import com.yapp.pet.domain.account_image.AccountImageService;
+import com.yapp.pet.domain.accountclub.AccountClub;
 import com.yapp.pet.domain.accountclub.AccountClubRepository;
+import com.yapp.pet.domain.club.service.ClubService;
 import com.yapp.pet.domain.comment.service.CommentService;
 import com.yapp.pet.domain.pet.service.PetService;
 import com.yapp.pet.domain.token.entity.Social;
@@ -29,6 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.EntityNotFoundException;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
@@ -52,6 +55,8 @@ public class AccountService {
     private final AccountClubRepository accountClubRepository;
 
     private final ApplicationEventPublisher eventPublisher;
+
+    private final ClubService clubService;
 
     public SignInResponse signInFromApple(AppleRequest appleRequest, Social social) {
         ApplePublicKeyResponse response = appleClient.getApplePublicKey();
@@ -141,7 +146,11 @@ public class AccountService {
 
         petService.deleteAllPetInfo(account);
 
-        commentService.deleteAllComment(account);
+        accountClubRepository.findAccountClubByAccountId(account.getId())
+                             .stream()
+                             .map(AccountClub::getClub)
+                             .collect(Collectors.toList())
+                             .forEach(c -> clubService.deleteClub(c.getId()));
 
         accountClubRepository.deleteAccountClubsByAccountId(account.getId());
 

--- a/src/main/java/com/yapp/pet/domain/accountclub/AccountClubRepository.java
+++ b/src/main/java/com/yapp/pet/domain/accountclub/AccountClubRepository.java
@@ -13,8 +13,16 @@ public interface AccountClubRepository extends JpaRepository<AccountClub, Long> 
     @Modifying(clearAutomatically = true)
     @Transactional
     @Query("delete from AccountClub ac where ac.account.id = :id")
-    int deleteAccountClubsByAccountId(@Param("id") long accountId);
+    void deleteAccountClubsByAccountId(@Param("id") long accountId);
+
+    @Modifying
+    @Transactional
+    @Query("delete from AccountClub ac where ac.club.id = :id")
+    void deleteAccountClubsByClubId(@Param("id") long clubId);
 
     @Query("select ac from AccountClub ac where ac.club.id = :clubId")
     List<AccountClub> findAccountClubByClubId(@Param("clubId") Long clubId);
+
+    @Query("select ac from AccountClub  ac where ac.account.id = :accountId")
+    List<AccountClub> findAccountClubByAccountId(@Param("accountId") Long accountId);
 }

--- a/src/main/java/com/yapp/pet/domain/club/repository/jpa/ClubRepositoryImpl.java
+++ b/src/main/java/com/yapp/pet/domain/club/repository/jpa/ClubRepositoryImpl.java
@@ -48,6 +48,7 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom{
                                                   rangeRequest.getUpperLeftLongitude(),
                                                   rangeRequest.getBottomRightLatitude(),
                                                   rangeRequest.getBottomRightLongitude()))
+                           .where(club.status.eq(ClubStatus.AVAILABLE))
                            .fetch();
     }
 

--- a/src/main/java/com/yapp/pet/domain/club/service/ClubService.java
+++ b/src/main/java/com/yapp/pet/domain/club/service/ClubService.java
@@ -99,10 +99,10 @@ public class ClubService {
             throw new NotLeaderException();
         }
 
-        commentRepository.deleteAllInBatch(
-                commentRepository.findCommentByClubId(findClub.getId())
-        );
-        accountClubRepository.deleteAllInBatch(findClub.getAccountClubs());
+        commentRepository.deleteCommentByClubId(findClub.getId());
+
+        accountClubRepository.deleteAccountClubsByClubId(findClub.getId());
+
         clubRepository.delete(findClub);
 
         return findClub.getId();

--- a/src/main/java/com/yapp/pet/domain/comment/CommentRepository.java
+++ b/src/main/java/com/yapp/pet/domain/comment/CommentRepository.java
@@ -14,8 +14,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @EntityGraph(attributePaths = {"account", "club"})
     List<Comment> findCommentByClubId(long clubId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Transactional
-    @Query("delete from Comment c where c.account.id = :id")
-    int deleteCommentByAccountId(@Param("id") long id);
+    @Query("delete from Comment c where c.club.id = :id")
+    void deleteCommentByClubId(@Param("id") long id);
 }

--- a/src/main/java/com/yapp/pet/domain/comment/service/CommentService.java
+++ b/src/main/java/com/yapp/pet/domain/comment/service/CommentService.java
@@ -40,8 +40,4 @@ public class CommentService {
 
         return savedComment.getId();
     }
-
-    public void deleteAllComment(Account account) {
-        commentRepository.deleteCommentByAccountId(account.getId());
-    }
 }


### PR DESCRIPTION
### PR Type
- [x] Bug Fix

### Fix Issue
- resolved: #186 

### Feature description
- 범위 내에 Club 조회 시 이용가능한 Club만 조회되야한다
- Account 삭제 시 , Account가 만든 Club 삭제, Account가 속한 AccountClub 삭제

### Checklist
- [x] 코드 변경 후 테스트 코드가 제대로 작동하는가?

Example
- [x] Work

